### PR TITLE
Export header component and update methone.datasektionen.se

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ If you are building a React app it is possible to include Methone as a component
   }
 
   return (
-    <div>
+    <div id="application" className="cerise"> // To color header (if used)
     <Methone config={config} />
+    <Header title="Methone"> // Optional header displayed below the bar
     <div>
       ...
     </div>

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -8,32 +8,6 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
 
     <title>methone</title>
-    <script type="text/javascript">
-      window.methone_conf = {
-          system_name: "calypso",
-          color_scheme: "pink",
-          login_text: "Hellooo",
-          login_href: "/",
-          links: [
-              {
-                  str: "Redigera nyheter",
-                  href: "/admin/list?itemType=post"
-              },
-              {
-                  str: "Redigera event",
-                  href: "/admin/list?itemType=event"
-              },
-              {
-                  str: "Facebook-import",
-                  href: "/admin/import"
-              },
-              {
-                  str: "Ny post",
-                  href: "/admin/new"
-              }
-          ]
-      };
-    </script>
   </head>
 
   <body>
@@ -42,49 +16,5 @@
     </noscript>
 
     <div id="methone-container-replace"></div>
-    <div id="application">
-      <div id="content">
-        <pre>
-# methone
-
-> The worlds first Top-Bar-as-a-Service
-
-## Install
-
-```bash
-npm install --save methone
-```
-
-## Usage
-
-```jsx
-import React, { Component } from 'react'
-import { Link } from 'react-router-dom'
-
-import Methone from 'methone'
-
-class Example extends Component {
-  render () {
-    const config = {
-      color_scheme: 'dark-blue',
-      system_name: 'Example',
-      links: [
-        <Link to="/info">Info</Link>
-      ],
-      login_text: 'Login',
-      login_href: '/login',
-    }
-    return (
-      <Methone config={config} />
-    )
-  }
-}
-```
-
-        </pre>
-        <div style="height:200px;">
-        </div>
-      </div>
-    </div>
   </body>
 </html>

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -8,6 +8,11 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
 
     <title>methone</title>
+    <meta
+      name="description"
+      content="The worlds first Top-Bar-as-a-Service"
+    />
+    <meta name="theme-color" content="#E83D84" />
   </head>
 
   <body>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,44 +2,96 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter, Link } from 'react-router-dom'
 
-import Methone from 'methone'
+import Methone, { Header } from 'methone'
 
 // This is an example that can be used during development
 
-window.methone_conf = {
-  color_scheme: 'cerise',
-  system_name: 'Example',
-  links: [
-    <Link to="/info" key="info">Info</Link>,
-    {
-      str: 'Test text',
-      href: '/more/test'
-    },
-    {
-      str: 'Other text that is long',
-      href: '/more/text'
-    },
-    {
-      str: 'Another one',
-      href: '/another/one'
-    },
-  ],
-  login_text: 'Login',
-  login_href: '/login',
-  ...window.methone_conf,
-  update: config => {
-    window.methone_conf = {
-      ...window.methone_conf,
-      ...config
-    }
-
-    const app = <BrowserRouter>
-      <Methone config={window.methone_conf} />
-    </BrowserRouter>
-
-    ReactDOM.render(app, document.getElementById('methone-container-replace'))
+const Example = () => {
+  
+  const methone_conf = {
+    color_scheme: 'cerise',
+    system_name: 'Example',
+    links: [
+      <Link to="/info" key="info">Info</Link>,
+      {
+        str: 'Test text',
+        href: '/more/test'
+      },
+      {
+        str: 'Other text that is long',
+        href: '/more/text'
+      },
+      {
+        str: 'Another one',
+        href: '/another/one'
+      },
+    ],
+    login_text: true ? "Login" : "Log out",
+    login_href: true ? "/login" : "/logout",
   }
+
+  return (
+    <BrowserRouter>
+      <div id="application" className="cerise">
+        <Methone config={methone_conf} />
+        <Header title="Methone" action={{onClick: _ => alert("Hej!"), text: "Test"}}>
+          <Link to="#">« Tillbaka</Link>
+        </Header>
+        <div style={{width: "100%", justifyContent: "center", alignItems: "center", display: "flex"}}>
+          <CodeExample />
+        </div>
+      </div>
+    </BrowserRouter>
+  )
 }
 
+const CodeExample = () => {
+  return (
+    <pre style={{width: "70%"}}>{`
+# methone
 
-window.methone_conf.update()
+> The worlds first Top-Bar-as-a-Service
+
+## Install
+
+
+npm install --save git+https://github.com/datasektionen/Methone.git
+
+## Usage (React example, functional component)
+----------------------------------------------------------------------
+import React, { Component } from 'react'
+import { BrowserRouter, Link } from 'react-router-dom'
+
+import Methone, { Header } from 'methone'
+
+class Example = () => {
+  const config = {
+    color_scheme: 'cerise',
+    system_name: 'Example',
+    links: [
+      <Link to="/info">Info</Link>
+    ],
+    login_text: 'Login',
+    login_href: '/login',
+  }
+
+  return (
+    <BrowserRouter>
+      <div id="application" className="cerise">
+        <Methone config={config} />
+        <Header title="Methone" action={{onClick: _ => alert("Hej!"), text: "Test"}}> // Action optional, don't pass props to not render
+          <Link to="#">« Tillbaka</Link> // Optional
+        </Header>
+        <div>
+          // ...body here
+        </div>
+      </div>
+    </BrowserRouter>
+  )
+}
+----------------------------------------------------------------------
+    `}</pre>
+  )
+}
+
+ReactDOM.render(<Example />, document.getElementById('methone-container-replace'))

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -52,12 +52,49 @@ const CodeExample = () => {
 
 > The worlds first Top-Bar-as-a-Service
 
-## Install
+https://github.com/datasektionen/methone#readme
 
+## How to use
+
+Everything works best when the parent element is an immidiate child of the body
+tag. You should probably lower your page content by 50 pixels.
+----------------------------------------------------------------------
+  <body>
+    <div id="methone-container-replace"> <!-- Should be a direct child of body -->
+    <nav>This will be replaced</nav>
+    </div>
+    ....
+
+  <script>
+    window.methone_conf = {
+    system_name: "meta-tv",
+    color_scheme: "cerise"
+    login_text: "Login with trisslott", // Default null, null hides button
+    login_href: "/login",
+    links: [
+      {
+      str: "About us",
+      href: "http://my.system.se/about-us",
+      }, ...
+    ]
+    }
+  </script>
+
+  <script async src="//methone.datasektionen.se/bar.js"></script>
+  <script>
+    // The config can be updated dynamically!
+    window.methone_conf.update({
+    login_text: "Log out",
+    login_href: "/logout"
+    })
+    // Only the provided keys will be updated.
+  </script>
+----------------------------------------------------------------------
+
+## Usage (React example, functional component)
 
 npm install --save git+https://github.com/datasektionen/Methone.git
 
-## Usage (React example, functional component)
 ----------------------------------------------------------------------
 import React, { Component } from 'react'
 import { BrowserRouter, Link } from 'react-router-dom'

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -47,7 +47,7 @@ const Example = () => {
 
 const CodeExample = () => {
   return (
-    <pre style={{width: "70%"}}>{`
+    <pre style={{width: "100%"}}>{`
 # methone
 
 > The worlds first Top-Bar-as-a-Service

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "methone",
-  "version": "0.7.7",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "methone",
-  "version": "0.7.7",
+  "version": "1.0.0",
   "description": "The worlds first Top-Bar-as-a-Service",
   "repository": {
     "type": "git",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,30 @@
+import React from 'react'
+
+/**
+ * Header component below the methone bar.
+ * 
+ * Saw this was implemented on some pages, why not create a reusable one.
+ */
+const Header = ({title = "", action = undefined, ...rest}) => {
+    return (
+        <header>
+            <div className="header-inner">
+            <div className="row">
+                <div className="header-left col-md-2">
+                    {/* One element to be inserted here. A link element <a> or <Link> if using React. */}
+                    {rest.children}
+                </div>
+                <div className="col-md-8">
+                <h2>{ title }</h2>
+                </div>
+                <div className="header-right col-md-2">
+                    {/* Action button. Used on datasektionen.se to edit a page (takes you to github bawang-content)*/}
+                    {action && <button className="primary-action" onClick={action.onClick}>{action.text}</button>}
+                </div>
+            </div>
+            </div>
+        </header>
+    )
+}
+
+export default Header

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
+// export default from './components/Methone'
 export default from './components/Methone'
+export { default as Header } from './components/Header'


### PR DESCRIPTION
This PR updates methone.datasektionen.se and exports a Header component.

## The header component
![image](https://user-images.githubusercontent.com/33149910/107126723-b92a7680-68b1-11eb-9da5-94d5306322cf.png)

This header is used on many of our pages. I therefore created a React component of it that can be exported and used so there is no need to write your own for the project. Since the default export is unchanged this change doesn't affect old systems.

## Updated example
Rewrote the example react page. Updated skeleton code.